### PR TITLE
Where

### DIFF
--- a/lib/Log/Async/CommandLine.pm6
+++ b/lib/Log/Async/CommandLine.pm6
@@ -78,7 +78,7 @@ Log::Async::CommandLine
 
 =head1 SYNOPSIS
 
-use Log::Async::CommandLine;
+    use Log::Async::CommandLine;
 
     ./someprogram [--trace]
                   [--debug]
@@ -89,6 +89,8 @@ use Log::Async::CommandLine;
                   [--silent | -q]
 
     ./someprogram [--logcolor] # Colorize log output
+
+    ./someprogram [--logthreadid] # Include thread id in log msg
 
     ./someprogram [--logfile=/var/log/mylogfile]
 
@@ -101,5 +103,7 @@ It will log either to $*OUT or the specified logfile messages with a
 level >= the specified level (or warning by default).
 
 Adding the '--logcolor' option will colorize the log output a little.
+
+Adding '--logthreadid' will include the thread id in the logged message.
 
 =end pod

--- a/lib/Log/Async/CommandLine.pm6
+++ b/lib/Log/Async/CommandLine.pm6
@@ -2,7 +2,6 @@ unit module Log::Async::CommandLine;
 
 use Log::Async;
 
-
 sub parse-log-args {
     my @keepargs;
 
@@ -11,6 +10,8 @@ sub parse-log-args {
     my $silent;
     my $color;
     my $threadid;
+    my @logwhere;
+    my %modulefilters;
 
     for @*ARGS {
         when '--silent'|'-q' {
@@ -22,6 +23,10 @@ sub parse-log-args {
         when /^'--'(trace|debug|info|warning|error|fatal)$/ {
             $loglevel = Loglevels::{$0.uc};
         }
+        when /^'--'(trace|debug|info|warning|error|fatal)
+               '=' (.+)$/ {
+            %modulefilters{~$1} = Loglevels::{$0.uc};
+        }
         when /^'--logfile='(.+)$/ {
             $logfh = open($0.Str, :a);
         }
@@ -31,13 +36,17 @@ sub parse-log-args {
         when '--logthreadid' {
             $threadid = True;
         }
+        when /^'--'logwhere['='(trace|debug|info|warning|error|fatal)]?$/ {
+            @logwhere.push: $0 ?? Loglevels::{$0.uc}
+                               !! |(TRACE,DEBUG,INFO,WARNING,ERROR,FATAL);
+        }
         default {
             push @keepargs, $_;
         }
     }
 
     my &print-log = $color
-      ?? sub ($logfh, $m, $threadid) {
+      ?? sub ($logfh, $m, $threadid, $logwhere, $loglevel, %modulefilters) {
              state %colors =
                  TRACE   => "\e[35;1m", # magenta
                  DEBUG   => "\e[34;1m", # blue
@@ -46,21 +55,39 @@ sub parse-log-args {
                  ERROR   => "\e[31;1m", # red
                  FATAL   => "\e[31;1m"; # red
 
+             my $minlevel = %modulefilters{"$m<where><module>.$m<where><method>"}
+                         // %modulefilters{"$m<where><module>"}
+                         // $loglevel;
+
+             return unless $m<level> >= $minlevel;
+
              $logfh.say("$m<when> " ~
                          ("($m<THREAD>.id()) " if $threadid) ~
+                         ("($m<where><module>" ~
+                             (".$m<where><method>" if $m<where><method>.chars) ~
+                             ') ' if $m<level> ∈ $logwhere) ~
                          "%colors{$m<level>}$m<level>.lc()" ~
                          ("\e[0m" unless $m<level> ~~ ERROR|FATAL) ~
                          ": $m<msg>\e[0m");
          }
-      !! sub ($logfh, $m, $threadid) {
+      !! sub ($logfh, $m, $threadid, $logwhere, $loglevel, %modulefilters) {
+             my $minlevel = %modulefilters{"$m<where><module>.$m<where><method>"}
+                         // %modulefilters{"$m<where><module>"}
+                         // $loglevel;
+
+             return unless $m<level> >= $minlevel;
+
              $logfh.say("$m<when> " ~
                         ("($m<THREAD>.id()) " if $threadid) ~
+                         ("($m<where><module>" ~
+                             (".$m<where><method>" if $m<where><method>.chars) ~
+                             ') ' if $m<level> ∈ $logwhere) ~
                         "$m<level>.lc(): $m<msg>");
          };
 
     logger.close-taps;
-    logger.add-tap(-> $m { &print-log($logfh, $m, $threadid) },
-                   :level(* >= $loglevel))
+    logger.add-tap(-> $m { &print-log($logfh, $m, $threadid, set(@logwhere),
+                                      $loglevel, %modulefilters) })
         unless $silent;
 
     @*ARGS = @keepargs;
@@ -86,13 +113,22 @@ Log::Async::CommandLine
                   [--warning]  # Default
                   [--error]
                   [--fatal]
-                  [--silent | -q]
 
-    ./someprogram [--logcolor] # Colorize log output
+    ./someprogram [--silent | -q] # Never output any message, overrides all
 
-    ./someprogram [--logthreadid] # Include thread id in log msg
+    ./someprogram --trace=Foo  # Set log level to trace just for module Foo
 
-    ./someprogram [--logfile=/var/log/mylogfile]
+    ./someprogram --trace=Foo.method # Set log level for a specific method
+
+    ./someprogram --logcolor # Colorize log output
+
+    ./someprogram --logthreadid # Include thread id in log msg
+
+    ./someprogram --logwhere # Include the module/method in log msg
+
+    ./someprogram --logwhere=trace # Include module/method just for trace
+
+    ./someprogram --logfile=/var/log/mylogfile
 
 =head1 DESCRIPTION
 
@@ -105,5 +141,18 @@ level >= the specified level (or warning by default).
 Adding the '--logcolor' option will colorize the log output a little.
 
 Adding '--logthreadid' will include the thread id in the logged message.
+
+Adding '--logwhere' or '--logwhere=<level>' will also log the calling
+module/method.
+
+You can also set the log level for a specific module or module+method with
+'--trace=Foo' or '--trace=Foo.method'.
+
+You can control things to the right level, for example:
+
+   --info --debug=Foo --trace=Foo.something
+
+will make the general level INFO, but DEBUG within the Foo module, and
+TRACE within the something() subroutine or method within Foo.
 
 =end pod

--- a/lib/Log/Async/CommandLine.pm6
+++ b/lib/Log/Async/CommandLine.pm6
@@ -86,9 +86,13 @@ sub parse-log-args {
          };
 
     logger.close-taps;
-    logger.add-tap(-> $m { &print-log($logfh, $m, $threadid, set(@logwhere),
-                                      $loglevel, %modulefilters) })
-        unless $silent;
+
+    unless $silent
+    {
+        logger.where = True;
+        logger.add-tap(-> $m { &print-log($logfh, $m, $threadid, set(@logwhere),
+                                          $loglevel, %modulefilters) })
+    }
 
     @*ARGS = @keepargs;
 }

--- a/t/05-concurrent.t
+++ b/t/05-concurrent.t
@@ -23,7 +23,7 @@ for ^100 {
          ;
 }
 
-sleep 3;
+sleep 2;
 
 is +@messages, 400, 'four hundred messages';
 is $string.chars, 4000, '4000 characters';

--- a/t/05-concurrent.t
+++ b/t/05-concurrent.t
@@ -23,7 +23,7 @@ for ^100 {
          ;
 }
 
-sleep 2;
+sleep 3;
 
 is +@messages, 400, 'four hundred messages';
 is $string.chars, 4000, '4000 characters';

--- a/t/08-commandline.t
+++ b/t/08-commandline.t
@@ -32,9 +32,10 @@ for @testcases -> @args, @keepargs,
         plan 9;
 
         my $lib = $*PROGRAM.parent.parent.child('lib');
+        my $t = $*PROGRAM.parent.parent.child('t');
         my $perl6 = ~$*EXECUTABLE;
 
-        my $out = run($perl6,"-I$lib", 't/command-line-test.pl',
+        my $out = run($perl6,"-I$lib,$t", 't/command-line-test.pl',
                       |@args, :out).out.slurp-rest;
 
         like $out, (@keepargs.elems

--- a/t/08-commandline.t
+++ b/t/08-commandline.t
@@ -2,30 +2,34 @@ use v6;
 use Test;
 
 my @testcases =
-    # args, keepargs, trace, debug, info, warning, error, fatal, color
-    [], [],            False, False, False, True,  True,  True,  False,
-    [<--trace>],   [], True,  True,  True,  True,  True,  True,  False,
-    [<--debug>],   [], False, True,  True,  True,  True,  True,  False,
-    [<--info>],    [], False, False, True,  True,  True,  True,  False,
-    [<-v>],        [], False, False, True,  True,  True,  True,  False,
-    [<--warning>], [], False, False, False, True,  True,  True,  False,
-    [<--error>],   [], False, False, False, False, True,  True,  False,
-    [<--fatal>],   [], False, False, False, False, False, True,  False,
-    [<-q>],        [], False, False, False, False, False, False, False,
-    [<--silent>],  [], False, False, False, False, False, False, False,
-    [<--logcolor>],[], False, False, False, True, True,   True,  True,
+    # args, keepargs, trace, debug, info, warning, error, fatal, color, thread
+    [], [],            False, False, False, True,  True,  True,  False, False,
+    [<--trace>],   [], True,  True,  True,  True,  True,  True,  False, False,
+    [<--debug>],   [], False, True,  True,  True,  True,  True,  False, False,
+    [<--info>],    [], False, False, True,  True,  True,  True,  False, False,
+    [<-v>],        [], False, False, True,  True,  True,  True,  False, False,
+    [<--warning>], [], False, False, False, True,  True,  True,  False, False,
+    [<--error>],   [], False, False, False, False, True,  True,  False, False,
+    [<--fatal>],   [], False, False, False, False, False, True,  False, False,
+    [<-q>],        [], False, False, False, False, False, False, False, False,
+    [<--silent>],  [], False, False, False, False, False, False, False, False,
+    [<--logcolor>],[], False, False, False, True, True,   True,  True,  False,
+
+    [<--logthreadid -v>], [],
+                       False, False, True,  True, True,   True,  False, True,
 
     # Don't mess with arguments that aren't mine
     [<foo -q bar mine --this --that>], [<foo bar mine --this --that>],
-                       False, False, False, False, False, False, False,
+                       False, False, False, False, False, False, False, False,
 ;
 
-plan @testcases.elems / 9;
+plan @testcases.elems / 10;
 
 for @testcases -> @args, @keepargs,
-                  $trace, $debug, $info, $warning, $error, $fatal, $color {
+                  $trace, $debug, $info, $warning, $error, $fatal,
+                  $color, $thread {
     subtest @args.Str, {
-        plan 8;
+        plan 9;
 
         my $lib = $*PROGRAM.parent.parent.child('lib');
         my $perl6 = ~$*EXECUTABLE;
@@ -78,5 +82,12 @@ for @testcases -> @args, @keepargs,
         } else {
             unlike $out, /\e\[\d\d\;1m/, 'Not Colorized';
         }
+
+        if $thread  {
+            like $out, /\(\d+\)/, 'Thread ID';
+        } else {
+            unlike $out, /\(\d+\)/, 'No Thread ID';
+        }
+
     }
 }

--- a/t/09-commandline-filter.t
+++ b/t/09-commandline-filter.t
@@ -1,0 +1,49 @@
+use v6;
+use Test;
+
+plan 21;
+
+my $lib = $*PROGRAM.parent.parent.child('lib');
+my $perl6 = ~$*EXECUTABLE;
+
+sub run-test(*@args) {
+    run($perl6, "-I$lib", 't/command-line-test.pl',
+        |@args, :out).out.slurp-rest;
+}
+
+my $out = run-test(<--testsubs>);
+ 
+unlike $out, /:s trace\: sub_a/, 'Sub No trace';
+unlike $out, /:s debug\: sub_a/, 'Sub No debug';
+unlike $out, /:s info\: sub_a/, 'Sub No info';
+like $out, /:s warning\: sub_a/, 'Sub Warning';
+like $out, /:s error\: sub_a/, 'Sub Error';
+like $out, /:s fatal\: sub_a/, 'Sub Fatal';
+
+$out = run-test(<--logwhere --testsubs>);
+
+like $out, /:s \(command\-line\-test.pl\) warning\: log warning/, 'where main';
+like $out, /:s \(TestModule.sub_a\) warning\: sub_a/, 'where sub_a';
+like $out, /:s \(TestModule.sub_b\) warning\: sub_b/, 'where sub_b';
+
+$out = run-test(<--logwhere=error --testsubs>);
+
+unlike $out, /:s \(command\-line\-test.pl\) warning\: log warning/,
+    'no where main';
+unlike $out, /:s \(TestModule.sub_a\) warning\: sub_a/, 'no where sub_a';
+unlike $out, /:s \(TestModule.sub_b\) warning\: sub_b/, 'no where sub_b';
+
+like $out, /:s \(command\-line\-test.pl\) error\: log error/, 'where main';
+like $out, /:s \(TestModule.sub_a\) error\: sub_a/, 'where sub_a';
+like $out, /:s \(TestModule.sub_b\) error\: sub_b/, 'where sub_b';
+
+$out = run-test(<--fatal --info=TestModule --debug=TestModule.sub_b --testsubs>);
+
+unlike $out, /:s error\: log error/, 'main no error';
+like $out, /:s fatal\: log fatal/, 'main fatal';
+
+unlike $out, /:s debug\: sub_a/, 'sub_a no debug';
+like $out, /:s info\: sub_a/, 'sub_a info';
+
+unlike $out, /:s trace\: sub_b/, 'sub_b no trace';
+like $out, /:s debug\: sub_b/, 'sub_b debug';

--- a/t/09-commandline-filter.t
+++ b/t/09-commandline-filter.t
@@ -4,7 +4,7 @@ use Test;
 plan 21;
 
 my $lib = $*PROGRAM.parent.parent.child('lib');
-my $t = $*PROGRAM.parent.parent.child('t');
+my $t = $*PROGRAM.parent;
 my $perl6 = ~$*EXECUTABLE;
 
 sub run-test(*@args) {

--- a/t/09-commandline-filter.t
+++ b/t/09-commandline-filter.t
@@ -4,10 +4,11 @@ use Test;
 plan 21;
 
 my $lib = $*PROGRAM.parent.parent.child('lib');
+my $t = $*PROGRAM.parent.parent.child('t');
 my $perl6 = ~$*EXECUTABLE;
 
 sub run-test(*@args) {
-    run($perl6, "-I$lib", 't/command-line-test.pl',
+    run($perl6, "-I$lib,$t", 't/command-line-test.pl',
         |@args, :out).out.slurp-rest;
 }
 

--- a/t/TestModule.pm
+++ b/t/TestModule.pm
@@ -1,0 +1,25 @@
+use v6;
+
+use Log::Async;
+
+unit module TestModule;
+
+sub sub_a is export
+{
+    trace   'sub_a';
+    debug   'sub_a';
+    info    'sub_a';
+    warning 'sub_a';
+    error   'sub_a';
+    fatal   'sub_a';
+}
+
+sub sub_b is export
+{
+    trace   'sub_b';
+    debug   'sub_b';
+    info    'sub_b';
+    warning 'sub_b';
+    error   'sub_b';
+    fatal   'sub_b';
+}

--- a/t/command-line-test.pl
+++ b/t/command-line-test.pl
@@ -1,7 +1,10 @@
 use v6;
 
+use lib 't';
+
 use Log::Async;
 use Log::Async::CommandLine;
+use TestModule;
 
 trace   'log trace';
 debug   'log debug';
@@ -11,3 +14,9 @@ error   'log error';
 fatal   'log fatal';
 
 say "ARGS: {@*ARGS.join(',')}";
+
+if '--testsubs' ∈ @*ARGS
+{
+    sub_a;
+    sub_b;
+}

--- a/t/command-line-test.pl
+++ b/t/command-line-test.pl
@@ -1,7 +1,5 @@
 use v6;
 
-use lib 't';
-
 use Log::Async;
 use Log::Async::CommandLine;
 use TestModule;


### PR DESCRIPTION
I copied some of MARTIMM's code into Log::Async to implement the 'where'.  Works very nicely, but may need to be refactored a bit to make the whole thing clean.

This works well as a proof of concept.

With CommandLine, you can add --logwhere to see which Module/Method logged the message.

Then, you can change the log levels for individual modules you might be working on:

`--info --debug=Foo --trace=Foo.something`

will make the general level INFO, but DEBUG within the Foo module only, and TRACE
within the something() subroutine or method within Foo.
