### PR TITLE
zone regex change

### DIFF
--- a/t/10-formatter.t
+++ b/t/10-formatter.t
@@ -10,7 +10,7 @@ sub tempfile {
 }
 
 my regex zone {
- [ '-' \d+ ':' \d+ | 'Z' ]
+ [ <[+-]> \d+ ':' \d+ | 'Z' ]
 }
 my regex date {
    \d+ '-' \d+ '-' \d+ 'T' \d+ ':' \d+ ':' \d+ '.' \d+ <zone>


### PR DESCRIPTION
The regex definition of the zone is insufficient. it fails the tests for people on the other side of Greenwich. It needs to test for '+' and '-'.

Marcel