### PR TITLE
Avoid using $*OUT during INIT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: perl6
 perl6:
   - 2017.05
+  - latest
 install:
   - rakudobrew build zef
   - zef install --depsonly .

--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ logger.done
 Tell the supplier it is done, then wait for the supply to be done.
 This is automatically called in the END phase.
 
+**untapped-ok**
+```p6
+logger.untapped-ok = True
+```
+This will suppress warnings about sending a log message before any
+taps are added.
+
 Context
 =======
 To display stack trace information, logging can be initialized with `add-context`.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Synopsis
 
 ```p6
 use Log::Async;
+logger.send-to($*OUT);
 
 trace 'how';
 debug 'now';

--- a/README.md
+++ b/README.md
@@ -165,19 +165,17 @@ logger.add-tap(-> $m { say $m.ctx.custom-method } )
 
 More Examples
 ========
-Close all taps and just send debug messages to stdout.
+Send debug messages to stdout.
 ```p6
-logger.close-taps;
 logger.send-to($*OUT,:level(DEBUG));
 ```
 
-Close all taps and send warnings, errors, and fatals to a log file.
+Send warnings, errors, and fatals to a log file.
 ```p6
-logger.close-taps;
 logger.send-to('/var/log/error.log',:level(* >= WARNING));
 ```
 
-Close all taps, and add one that prints the file, line number, message, and utc timestamp.
+Add a tap that prints the file, line number, message, and utc timestamp.
 ```p6
 logger.send-to($*OUT,
   formatter => -> $m, :$fh {

--- a/eg/simple.p6
+++ b/eg/simple.p6
@@ -1,0 +1,10 @@
+#!/usr/bin/env perl6
+
+use Log::Async;
+logger.send-to($*OUT);
+
+trace 'how';
+debug 'now';
+warning 'brown';
+info 'cow';
+fatal 'ow';

--- a/lib/Log/Async.pm6
+++ b/lib/Log/Async.pm6
@@ -19,12 +19,6 @@ class Log::Async:ver<0.0.3>:auth<github:bduggan> {
       $.contextualizer = $context;
     }
 
-    method new {
-        my $self = callsame;
-        $self.send-to($*OUT);
-        $self;
-    }
-
     method close-taps {
         .close for @.taps;
     }

--- a/lib/Log/Async.pm6
+++ b/lib/Log/Async.pm6
@@ -7,6 +7,7 @@ class Log::Async:ver<0.0.3>:auth<github:bduggan> {
     has Tap @.taps;
     has Supply $.messages;
     has $.contextualizer is rw;
+    has $.untapped-ok is rw = False;
 
     my $instance;
     method instance {
@@ -65,6 +66,11 @@ class Log::Async:ver<0.0.3>:auth<github:bduggan> {
     ) is hidden-from-backtrace {
         my $ctx = $_.generate with self.contextualizer;
         my $m = { :$msg, :$level, :$when, :$*THREAD, :$frame, :$ctx };
+        if @.taps == 0 and not $!untapped-ok {
+            note 'Message sent without taps.';
+            note 'Try "logger.send-to($*ERR)" or "logger.untapped-ok = True"';
+            $!untapped-ok = True;
+        }
         (start $.source.emit($m))
           .then({ say $^p.cause unless $^p.status == Kept });
     }

--- a/lib/Log/Async/CommandLine.pm6
+++ b/lib/Log/Async/CommandLine.pm6
@@ -14,6 +14,7 @@ sub parse-log-args {
     for @*ARGS {
         when '--silent'|'-q' {
             $silent = True;
+            logger.untapped-ok = True;
         }
         when '-v' {
             $loglevel = INFO;
@@ -57,7 +58,6 @@ sub parse-log-args {
                         "$m<level>.lc(): $m<msg>");
          };
 
-    logger.close-taps;
     logger.add-tap(-> $m { &print-log($logfh, $m, $threadid) },
                    :level(* >= $loglevel))
         unless $silent;

--- a/t/03-log.t
+++ b/t/03-log.t
@@ -9,6 +9,7 @@ my $out = "";
 $*OUT = IO::Handle but role { method say($arg) { $out ~= $arg } };
 
 set-logger(Log::Async.new);
+logger.send-to($*OUT);
 
 trace "albatross";
 sleep 0.1;

--- a/t/04-filter.t
+++ b/t/04-filter.t
@@ -5,7 +5,6 @@ use Log::Async;
 
 plan 8;
 
-logger.close-taps;
 my $last = "my";
 logger.add-tap({ $last = $^message<msg> }, :level(TRACE));
 

--- a/t/05-concurrent.t
+++ b/t/05-concurrent.t
@@ -7,8 +7,6 @@ plan 3;
 
 my $when = now + 1;
 
-logger.close-taps;
-
 my @messages;
 logger.add-tap({ push @messages, $^message });
 

--- a/t/06-sleep.t
+++ b/t/06-sleep.t
@@ -5,8 +5,6 @@ use Log::Async;
 
 plan 2;
 
-logger.close-taps;
-
 my $message;
 logger.add-tap({ sleep 1; $message = $^m<msg> });
 

--- a/t/07-done.t
+++ b/t/07-done.t
@@ -8,6 +8,7 @@ plan 2;
 my $out = "";
 $*OUT = IO::Handle but role { method say($arg) { $out ~= $arg } };
 set-logger(Log::Async.new);
+logger.send-to($*OUT);
 
 info 'first';
 info 'second';

--- a/t/08-commandline.t
+++ b/t/08-commandline.t
@@ -35,7 +35,7 @@ for @testcases -> @args, @keepargs,
         my $t = $*PROGRAM.parent.parent.child('t');
         my $perl6 = ~$*EXECUTABLE;
 
-        my $out = run($perl6,"-I$lib,$t", 't/command-line-test.pl',
+        my $out = run($perl6,"-I$lib,$t", ~$t.child('command-line-test.pl'),
                       |@args, :out).out.slurp-rest;
 
         like $out, (@keepargs.elems

--- a/t/09-commandline-filter.t
+++ b/t/09-commandline-filter.t
@@ -8,7 +8,7 @@ my $t = $*PROGRAM.parent;
 my $perl6 = ~$*EXECUTABLE;
 
 sub run-test(*@args) {
-    run($perl6, "-I$lib,$t", 't/command-line-test.pl',
+    run($perl6, "-I$lib,$t", $t.child('command-line-test.pl'),
         |@args, :out).out.slurp-rest;
 }
 

--- a/t/10-formatter.t
+++ b/t/10-formatter.t
@@ -17,7 +17,6 @@ my regex date {
 }
 
 {
-  logger.close-taps;
   my $output will leave { .unlink } = tempfile;
   logger.send-to($output);
   info "this is some interesting info";
@@ -25,11 +24,11 @@ my regex date {
   my $lines = $output.slurp;
   like $lines, / <date> ' (' \d+ ') info: this is some interesting info' /,
                 'default format';
+  logger.close-taps;
 }
 
 {
   Log::Async.set-instance(Log::Async.new);
-  logger.close-taps;
   my $output will leave { .unlink } = tempfile;
   logger.send-to($output);
   info "this is some more interesting info";
@@ -37,22 +36,22 @@ my regex date {
   my $lines = $output.slurp;
   like $lines, / <date> ' (' \d+ ') info: this is some more interesting info' /,
                 'default format again';
+  logger.close-taps;
 }
 
 {
   Log::Async.set-instance(Log::Async.new);
-  logger.close-taps;
   my $output will leave { .unlink } = tempfile;
   logger.send-to($output, formatter => -> $m, :$fh { $fh.say: "this is my own format" });
   info "this will not be printed";
   logger.done;
   my $lines = $output.slurp;
   is $lines, "this is my own format\n", "custom format";
+  logger.close-taps;
 }
 
 {
   Log::Async.set-instance(Log::Async.new);
-  logger.close-taps;
   my $output will leave { .unlink } = tempfile;
   logger.send-to($output, formatter => -> $m, :$fh { $fh.say: "{$m<level>.lc}: $m<msg>" });
   trace "tracing paper";
@@ -63,11 +62,11 @@ my regex date {
   is-deeply @lines, ["trace: tracing paper",
                      "debug: this is not a bug",
                      "warning: this is your final warning"], "custom format again";
+  logger.close-taps;
 }
 
 {
   Log::Async.set-instance(Log::Async.new);
-  logger.close-taps;
   my $output will leave { .unlink } = tempfile;
   logger.send-to($output, :level(DEBUG), formatter => -> $m, :$fh { $fh.say: "{$m<level>.lc}: $m<msg>" });
   trace "tracing paper";

--- a/t/12-context.t
+++ b/t/12-context.t
@@ -7,7 +7,6 @@ plan 1;
 
 my @lines;
 my $out = IO::Handle but role { method say($arg) { @lines.push: $arg } };
-logger.close-taps;
 logger.add-context;
 logger.send-to($out,
   formatter => -> $m, :$fh {

--- a/t/13-remove-tap.t
+++ b/t/13-remove-tap.t
@@ -8,7 +8,6 @@ plan 4;
 my @lines;
 my $out = IO::Handle but role { method say($arg) { @lines.push: $arg } };
 
-logger.close-taps;
 my $one = logger.send-to($out, formatter => -> $m, :$fh { @lines.push: "one" } );
 my $two = logger.send-to($out, formatter => -> $m, :$fh { @lines.push: "two" } );
 my $three = logger.send-to($out, formatter => -> $m, :$fh { @lines.push: "three" } );

--- a/t/14-frame.t
+++ b/t/14-frame.t
@@ -4,7 +4,7 @@ use lib 'lib';
 use Log::Async;
 plan 6;          # NB: line numbers are hard coded below, modify with care
 
-logger.close-taps;
+
 my @all;
 my $out = IO::Handle but role { method say($str) { @all.push: $str } };
 

--- a/t/15-untapped.t
+++ b/t/15-untapped.t
@@ -1,0 +1,12 @@
+use v6;
+use Test;
+use lib 'lib';
+
+plan 2;
+
+use Log::Async;
+
+ok logger.untapped-ok == False, 'untapped-ok set to false';
+logger.untapped-ok = True;
+ok logger.untapped-ok, 'set to true';
+


### PR DESCRIPTION
This PR requires an explicit `send-to` at run time to send log messages to `$*OUT`, instead of doing it during the `INIT` phase.  ( See #14 ).  This makes it easier to set up non-default loggers (since the `$*OUT` one won't be automatically created, so won't have to be removed), but may also make an initial setup a little harder since you have to explicitly say that log messages should go to `$*OUT` (though you get some flexibility, since you could send them to e.g. `$*ERR` or wherever, instead)