### PR TITLE
Allow setting out-buffer, don't test message order

### DIFF
--- a/lib/Log/Async.pm6
+++ b/lib/Log/Async.pm6
@@ -51,13 +51,13 @@ class Log::Async:ver<0.0.6>:auth<github:bduggan> {
         }, done => { $fh.close }, quit => { $fh.close }, |args
     }
 
-    multi method send-to(Str $path, Code :$formatter, |args --> Tap) {
-        my $fh = open($path, :a, :!out-buffer) or die "error opening $path";
+    multi method send-to(Str $path, Code :$formatter, Bool :$out-buffer = False, |args --> Tap) {
+        my $fh = open($path,:a,:$out-buffer) or die "error opening $path";
         self.send-to($fh, :$formatter, |args);
     }
 
-    multi method send-to(IO::Path $path, Code :$formatter,  |args --> Tap) {
-        my $fh = $path.open(:a) or die "error opening $path";
+    multi method send-to(IO::Path $path, Code :$formatter, Bool :$out-buffer = False, |args --> Tap) {
+        my $fh = $path.open(:a,:$out-buffer) or die "error opening $path";
         self.send-to($fh, :$formatter, |args);
     }
 

--- a/t/10-formatter.t
+++ b/t/10-formatter.t
@@ -59,9 +59,9 @@ my regex date {
   warning "this is your final warning";
   logger.done;
   my @lines = $output.slurp.lines;
-  is-deeply @lines, ["trace: tracing paper",
+  is-deeply @lines.sort, ["trace: tracing paper",
                      "debug: this is not a bug",
-                     "warning: this is your final warning"], "custom format again";
+                     "warning: this is your final warning"].sort, "custom format again";
   logger.close-taps;
 }
 
@@ -76,3 +76,5 @@ my regex date {
   my @lines = $output.slurp.lines;
   is-deeply @lines, [ "debug: this is not a bug" ], "custom format with filter";
 }
+
+# vim: ft=perl6


### PR DESCRIPTION
* Fixes test failures when threads send messages out of order.
* Add support for `:out-buffer` argument.