### PR TITLE
Fix flapping tests

### DIFF
--- a/t/03-log.t
+++ b/t/03-log.t
@@ -9,8 +9,8 @@ my $out;
 my $out-channel = Channel.new;
 sub wait-for-out {
     react {
-        whenever $out-channel  { $out = $_;  done }
-        whenever Promise.in(3) { $out = Nil; done }
+        whenever $out-channel   { $out = $_;  done }
+        whenever Promise.in(20) { $out = Nil; done }
     }
 }
 $*OUT = $*OUT but role { method say($arg) { $out-channel.send: $arg } };

--- a/t/04-filter.t
+++ b/t/04-filter.t
@@ -9,8 +9,8 @@ my $last = "my";
 my $last-channel = Channel.new;
 sub wait-for-out {
     react {
-        whenever $last-channel { $last = $_;  done }
-        whenever Promise.in(3) { $last = Nil; done }
+        whenever $last-channel  { $last = $_;  done }
+        whenever Promise.in(20) { $last = Nil; done }
     }
 }
 
@@ -55,7 +55,7 @@ sub wait-for-channel($channel) {
     gather react {
         my $count = 0;
         whenever $channel { take $_; done if ++$count == 3 }
-        whenever Promise.in(3) { done }
+        whenever Promise.in(20) { done }
     }
 }
 is (wait-for-channel $debug-or-error), <3 4 6>, 'filter with junction';


### PR DESCRIPTION
By removing occurrences of `sleep 0.1`. The difficulty here is to make
tests fail if a message is not delivered (instead of hanging
forever). This also makes tests significantly faster (because tests
can immediately proceed instead of having to wait for a fixed amount
of time).

There are still some `sleep` calls left, but these are with much
larger timeouts (1 or 2 seconds), so it should be fine for now.

Resolves #28.