### PR TITLE
Fix invalid license in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -17,7 +17,7 @@
     "description" : "Asynchronous logging with supplies and taps",
     "test-depends" : [ ],
     "version" : "0.0.7",
-    "license" : "Perl",
+    "license" : "Artistic-1.0-Perl",
     "authors" : [
         "Brian Duggan"
     ]


### PR DESCRIPTION
The license field should be a valid SPDX identifier as mentioned under https://docs.raku.org/language/modules#Preparing_the_module